### PR TITLE
Fixed out of bounds exception

### DIFF
--- a/sonar-scm-mercurial-plugin/src/main/java/org/sonar/plugins/scm/mercurial/MercurialBlameCommand.java
+++ b/sonar-scm-mercurial-plugin/src/main/java/org/sonar/plugins/scm/mercurial/MercurialBlameCommand.java
@@ -99,7 +99,7 @@ public class MercurialBlameCommand extends BlameCommand {
       LOG.debug("The mercurial blame command [" + cl.toString() + "] failed: " + stderr.getOutput());
     }
     List<BlameLine> lines = consumer.getLines();
-    if (lines.size() == inputFile.lines() - 1) {
+    if (lines.size() > 0 && lines.size() == inputFile.lines() - 1) {
       // SONARPLUGINS-3097 Mercurial do not report blame on last empty line
       lines.add(lines.get(lines.size() - 1));
     }


### PR DESCRIPTION
INFO: java.lang.ArrayIndexOutOfBoundsException: -1
INFO: at java.util.ArrayList.elementData(Unknown Source)
INFO: at java.util.ArrayList.get(Unknown Source)
INFO: at org.sonar.plugins.scm.mercurial.MercurialBlameCommand.blame(MercurialBlameCommand.java:104)
INFO: at org.sonar.plugins.scm.mercurial.MercurialBlameCommand.access$000(MercurialBlameCommand.java:42)
INFO: at org.sonar.plugins.scm.mercurial.MercurialBlameCommand$1.call(MercurialBlameCommand.java:83)
INFO: at org.sonar.plugins.scm.mercurial.MercurialBlameCommand$1.call(MercurialBlameCommand.java:80)

This happens if blame fails (e.g. file not under version control) and the source file has only one line of code